### PR TITLE
Centralize build versions in libs.versions.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default build-all stop clean build uberjar uber dist stage clean-docs sync-revealjs versioncheck upgrade-wrapper
 
+GRADLE_VERSION := $(shell sed -n 's/^gradle *= *"\(.*\)"/\1/p' gradle/libs.versions.toml)
+
 default: versioncheck
 
 build-all: stage
@@ -36,4 +38,4 @@ versioncheck:
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 // Change mainName to the name of Kotlin file that has the presentation you want to serve
 val mainName = "SlidesKt"
 
+val projectName = "kslides"
+val cleanTask = "clean"
+val revealJsDir = "docs/revealjs"
+
 application {
   mainClass.set(mainName)
 }
@@ -21,13 +25,13 @@ dependencies {
 
 tasks.shadowJar {
   isZip64 = true
-  archiveFileName.set("kslides.jar")
+  archiveFileName.set("$projectName.jar")
   mergeServiceFiles()
   exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*")
-  mustRunAfter("clean")
+  mustRunAfter(cleanTask)
   manifest {
     attributes(
-      "Implementation-Title" to "kslides",
+      "Implementation-Title" to projectName,
       "Implementation-Version" to version,
       "Built-Date" to Date(),
       "Built-JDK" to System.getProperty("java.version"),
@@ -36,10 +40,10 @@ tasks.shadowJar {
   }
 }
 
-tasks.register("stage") { dependsOn("clean", "shadowJar") }
+tasks.register("stage") { dependsOn(cleanTask, "shadowJar") }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(libs.versions.jvm.get().toInt())
 }
 
 // Unpack reveal.js assets from the kslides-core JAR into docs/revealjs/.
@@ -48,8 +52,8 @@ kotlin {
 // generated docs/*.html have working JS/CSS references when published to
 // Netlify / GitHub Pages.
 tasks.register<Sync>("syncRevealJs") {
-  group = "kslides"
-  description = "Unpacks reveal.js assets from the kslides-core JAR into docs/revealjs/."
+  group = projectName
+  description = "Unpacks reveal.js assets from the kslides-core JAR into $revealJsDir/."
 
   val coreJar = configurations.runtimeClasspath.map { rc ->
     rc.files.single { it.name.startsWith("kslides-core-") }
@@ -60,7 +64,7 @@ tasks.register<Sync>("syncRevealJs") {
     eachFile { relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray()) }
     includeEmptyDirs = false
   }
-  into(layout.projectDirectory.dir("docs/revealjs"))
+  into(layout.projectDirectory.dir(revealJsDir))
 }
 
 // Single source of truth for images assets: docs/images/ (committed for GitHub Pages).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 ben-manes-versions = "0.54.0"
+gradle = "9.5.0"
+jvm = "17"
 kotlin = "2.3.21"
 kslides = "1.0.0"
 shadow = "9.4.1"


### PR DESCRIPTION
## Summary
- Move Gradle (9.5.0) and JVM (17) versions into `gradle/libs.versions.toml`
- `build.gradle.kts` reads the JVM version via `libs.versions.jvm.get()`
- `Makefile` extracts `GRADLE_VERSION` from the catalog with `sed` and uses it in the `upgrade-wrapper` target
- Consolidate repeated string literals in `build.gradle.kts` (`projectName`, `cleanTask`, `revealJsDir`)

## Test plan
- [x] `./gradlew help` succeeds with the new toolchain wiring
- [x] `make -n upgrade-wrapper` resolves to `--gradle-version=9.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)